### PR TITLE
Update mongodb version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "babel-runtime": "^5.4.7",
     "debug": "^2.2.0",
-    "mongodb": "^1.4.5",
+    "mongodb": "^2.0.42",
     "thunkify": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Had trouble building the bson dependency that mongodb ^1.4.5 depended on. Seems to work fine with a more recent driver as well.